### PR TITLE
fix "Error: Unable to access jarfile /opt/fakeSMTP-1.13.jar"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN wget -q http://nilhcem.github.com/FakeSMTP/downloads/fakeSMTP-latest.zip && 
 EXPOSE 25
 VOLUME ["/var/mail"]
 
-CMD java -jar /opt/fakeSMTP-1.13.jar -s -b -o /var/mail
+CMD java -jar /opt/fakeSMTP-2.0.jar -s -b -o /var/mail


### PR DESCRIPTION
it latest.zip now contains /opt/fakeSMTP-2.0.jar

perhaps it should depend on the project tags and build tags based on the source project.